### PR TITLE
Increase Routes size to uint32

### DIFF
--- a/template/http/handler.tmpl
+++ b/template/http/handler.tmpl
@@ -13,7 +13,7 @@
     type handler struct {}
 
     // Bitmask to configure which routes to register.
-    type Routes uint8
+    type Routes uint32
 
     func (rs Routes) has(r Routes) bool { return rs&r != 0 }
 


### PR DESCRIPTION
uint8 overflows quickly if there are too many edges on an entity resulting in more than 8 options.